### PR TITLE
added local logging option for docker_auth container

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,24 @@ some lib files from [puppet-elasticsearch](https://github.com/elastic/puppet-ela
 If you want to start the server from a container (manage_as => 'container'), you will need to create
 the folder where $config_file will be written, outside of this module:
 
-	  file { '/etc/docker_auth/': ensure => 'directory', }
-	  class { '::docker_distribution':
-	    manage_as                    => 'container',
-	    container_image              => 'docker.io/registry:2.6.0',
-	    http_tls                     => true,
-	    storage_delete               => true,
-	    auth_type                    => 'token',
-	    auth_token_realm             => "https://${::fqdn}:5002/auth",
-	    auth_token_issuer            => 'Auth Service',
-	    auth_token_rootcertbundle    => "/var/lib/puppet/ssl/certs/${::fqdn}.pem",
-	  }
+		  file { '/etc/docker_auth/': ensure => 'directory', }
+		  class { '::docker_distribution':
+		    manage_as                    => 'container',
+		    container_image              => 'docker.io/registry:2.6.0',
+		    http_tls                     => true,
+		    storage_delete               => true,
+		    auth_type                    => 'token',
+		    auth_token_realm             => "https://${::fqdn}:5002/auth",
+		    auth_token_issuer            => 'Auth Service',
+		    auth_token_rootcertbundle    => "/var/lib/puppet/ssl/certs/${::fqdn}.pem",
+		  }
 
-	  class { '::docker_auth':
-	    manage_as           => 'container',
-	    container_image     => 'docker.io/cesanta/docker_auth:1.2',
-            container_log_local => false,
-	    server_addr         => ':5002',
-	  }
+		  class { '::docker_auth':
+		    manage_as           => 'container',
+		    container_image     => 'docker.io/cesanta/docker_auth:1.2',
+       		     container_log_local => false,
+		    server_addr         => ':5002',
+		  }
 
 Note that if you set container_log_local to true (default is false), logs from the docker_auth container will be written to a directory, /var/log/docker_auth on the docker engine system.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ some lib files from [puppet-elasticsearch](https://github.com/elastic/puppet-ela
 If you want to start the server from a container (manage_as => 'container'), you will need to create
 the folder where $config_file will be written, outside of this module:
 
-          file { '/etc/docker_auth/': ensure => 'directory', }
+	  file { '/etc/docker_auth/': ensure => 'directory', }
 	  class { '::docker_distribution':
 	    manage_as                    => 'container',
 	    container_image              => 'docker.io/registry:2.6.0',

--- a/README.md
+++ b/README.md
@@ -24,22 +24,25 @@ If you want to start the server from a container (manage_as => 'container'), you
 the folder where $config_file will be written, outside of this module:
 
           file { '/etc/docker_auth/': ensure => 'directory', }
-		  class { '::docker_distribution':
-		    manage_as                    => 'container',
-		    container_image              => 'docker.io/registry:2.6.0',
-		    http_tls                     => true,
-		    storage_delete               => true,
-		    auth_type                    => 'token',
-		    auth_token_realm             => "https://${::fqdn}:5002/auth",
-		    auth_token_issuer            => 'Auth Service',
-		    auth_token_rootcertbundle    => "/var/lib/puppet/ssl/certs/${::fqdn}.pem",
-		  }
+	  class { '::docker_distribution':
+	    manage_as                    => 'container',
+	    container_image              => 'docker.io/registry:2.6.0',
+	    http_tls                     => true,
+	    storage_delete               => true,
+	    auth_type                    => 'token',
+	    auth_token_realm             => "https://${::fqdn}:5002/auth",
+	    auth_token_issuer            => 'Auth Service',
+	    auth_token_rootcertbundle    => "/var/lib/puppet/ssl/certs/${::fqdn}.pem",
+	  }
 
-		  class { '::docker_auth':
-		    manage_as       => 'container',
-		    container_image => 'docker.io/cesanta/docker_auth:1.2',
-		    server_addr     => ':5002',
-		  }
+	  class { '::docker_auth':
+	    manage_as           => 'container',
+	    container_image     => 'docker.io/cesanta/docker_auth:1.2',
+            container_log_local => false,
+	    server_addr         => ':5002',
+	  }
+
+Note that if you set container_log_local to true (default is false), logs from the docker_auth container will be written to a directory, /var/log/docker_auth on the docker engine system.
 
 ### Use the above for a local docker distribution proxy (works only with distribution version 2.6 and up):
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ the folder where $config_file will be written, outside of this module:
 		  class { '::docker_auth':
 		    manage_as           => 'container',
 		    container_image     => 'docker.io/cesanta/docker_auth:1.2',
-       		     container_log_local => false,
+		    container_log_local => false,
 		    server_addr         => ':5002',
 		  }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,21 +82,22 @@
 #   Defaults to [{ "match"   => { "account" => "" }, "actions" => ["*"] } ] (allow all for all accounts)
 #
 class docker_auth (
-  $manage_as          = $::docker_auth::params::manage_as,
-  $container_image    = $::docker_auth::params::container_image,
-  $package_name       = $::docker_auth::params::package_name,
-  $package_ensure     = $::docker_auth::params::package_ensure,
-  $service_name       = $::docker_auth::params::service_name,
-  $service_ensure     = $::docker_auth::params::service_ensure,
-  $service_enable     = $::docker_auth::params::service_enable,
+  $manage_as           = $::docker_auth::params::manage_as,
+  $container_image     = $::docker_auth::params::container_image,
+  $package_name        = $::docker_auth::params::package_name,
+  $package_ensure      = $::docker_auth::params::package_ensure,
+  $service_name        = $::docker_auth::params::service_name,
+  $service_ensure      = $::docker_auth::params::service_ensure,
+  $service_enable      = $::docker_auth::params::service_enable,
   #
-  $server_addr        = $::docker_auth::params::server_addr,
-  $server_certificate = $::docker_auth::params::server_certificate,
-  $server_key         = $::docker_auth::params::server_key,
-  $token_issuer       = $::docker_auth::params::token_issuer,
-  $token_expiration   = $::docker_auth::params::token_expiration,
-  $users              = $::docker_auth::params::users,
-  $acls               = $::docker_auth::params::acls,
+  $server_addr         = $::docker_auth::params::server_addr,
+  $server_certificate  = $::docker_auth::params::server_certificate,
+  $server_key          = $::docker_auth::params::server_key,
+  $token_issuer        = $::docker_auth::params::token_issuer,
+  $token_expiration    = $::docker_auth::params::token_expiration,
+  $container_log_local = $::docker_auth::params::container_log_local,
+  $users               = $::docker_auth::params::users,
+  $acls                = $::docker_auth::params::acls,
 ) inherits docker_auth::params {
   validate_re($manage_as, '^(service|container)$')
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,14 +1,23 @@
 class docker_auth::install {
   if $docker_auth::manage_as == 'container' {
+
+    if $::docker_auth::container_log_local {
+      $log_mount = '/var/log/docker_auth:/logs'
+      $command = ' -log_dir=/logs  /config/auth_config.yml'
+    } else {
+      $log_mount = undef
+      $command = ' /config/auth_config.yml'
+    }
+
     docker::run { $docker_auth::package_name:
       image           => $docker_auth::container_image,
       volumes         => [
         "${docker_auth::config_file}:/config/auth_config.yml",
         "${docker_auth::server_certificate}:${docker_auth::server_certificate}",
         "${docker_auth::server_key}:${docker_auth::server_key}",
-        '/var/log/docker_auth:/logs',
+        $log_mount,
       ],
-      command         => ' --v=2  -log_dir=/logs  /config/auth_config.yml',
+      command         => $command,
       restart_service => true,
       net             => 'host',
       detach          => false,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,7 +8,7 @@ class docker_auth::install {
         "${docker_auth::server_key}:${docker_auth::server_key}",
         '/var/log/docker_auth:/logs',
       ],
-      command         => ' --v=2  -log_dir=/logs  /config/auth_config.yml'
+      command         => ' --v=2  -log_dir=/logs  /config/auth_config.yml',
       restart_service => true,
       net             => 'host',
       detach          => false,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,6 +8,7 @@ class docker_auth::install {
         "${docker_auth::server_key}:${docker_auth::server_key}",
         '/var/log/docker_auth:/logs',
       ],
+      command         => ' --v=2  -log_dir=/logs  /config/auth_config.yml'
       restart_service => true,
       net             => 'host',
       detach          => false,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,6 +6,7 @@ class docker_auth::install {
         "${docker_auth::config_file}:/config/auth_config.yml",
         "${docker_auth::server_certificate}:${docker_auth::server_certificate}",
         "${docker_auth::server_key}:${docker_auth::server_key}",
+        '/var/log/docker_auth:/logs',
       ],
       restart_service => true,
       net             => 'host',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,8 @@ class docker_auth::params {
   $token_issuer = 'Auth Service'
   $token_expiration = 900
 
+  $container_log_local = false
+
   # Allow anonymous (no "docker login") access.
   $users = { '' => {} }
 


### PR DESCRIPTION
When running as a container, logs are currently only to /tmp within the container.  I have added a new parameter, container_log_local that will set logging up to /var/log/docker_auth/ directory, as cesanta/docker_auth suggests, when running as a container.  The default value is false, so the behavior of this module should not change.  Logging to local dock engine host filesystem will only happen if container_log_local is set to true.  

If you accept, I'm hoping you can squash my various commits down as you merge (https://github.com/blog/2243-rebase-and-merge-pull-requests)

Thanks alot,
Erin